### PR TITLE
Hotfix: Python requirements install with Venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,26 @@ FROM ubuntu
 WORKDIR /app
 COPY . .
 
-ENV DEBIAN_FRONTEND="noninteractive" TZ="Africa/Johannesburg"
+# Set environment variables
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Chicago"
 
-# Install necessary dependencies for starting mysql
-RUN apt-get -y update && apt-get -y install make sudo mysql-server libmysqlclient-dev
-RUN service mysql start && mysql mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY '';FLUSH PRIVILEGES;"
+# Install system dependencies, including python3-venv for creating virtual environments and Redis
+RUN apt-get -y update && \
+    apt-get -y install make sudo mysql-server libmysqlclient-dev python3 python3-pip python3-venv redis-server && \
+    apt-get clean
 
-# Install remaining dependencies
-RUN make install
+# Start MySQL and set root user authentication method
+RUN service mysql start && \
+    mysql mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY ''; FLUSH PRIVILEGES;"
+
+# Create and activate a virtual environment, install dependencies
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --upgrade pip
+RUN pip install -r requirements_dev.txt
 
 # Make start script executable
 RUN chmod +x start.sh
 
-# Start MySQL and run server
-CMD ["/bin/bash", "/app/start.sh"]
+# Start MySQL, Redis, and run server
+CMD service redis-server start && service mysql start && /bin/bash /app/start.sh

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@
 
 # Define variables
 MAKE          := make
-VENV		  := .venv
-PYTHON		  := $(VENV)/bin/python3
+VENV          := .venv
+PYTHON        := $(VENV)/bin/python3
 
 # Define directories
 MEDIA_DIR     := media

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
 
 # Define variables
 MAKE          := make
-PYTHON        := python3
+VENV 		  := .venv
+PYTHON    	  := $(VENV)/bin/python3
 
 # Define directories
 MEDIA_DIR     := media
@@ -20,8 +21,9 @@ MAIN          := manage.py
 
 install:
 	sudo apt-get -y update
-	sudo apt-get -y install redis mysql-server libmysqlclient-dev python3-pip
-	pip3 install -r requirements_dev.txt --upgrade
+	sudo apt-get -y install redis mysql-server libmysqlclient-dev python3-pip python3-venv
+	python3 -m venv $(VENV)
+	$(VENV)/bin/pip install -r requirements_dev.txt --upgrade
 	$(MAKE) db
 
 start-mysql:

--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,14 @@ create-db:
 db: start-mysql clean create-db migrations
 
 docker-rebuild:
-	docker-compose build
+	docker compose build
 	$(MAKE) docker-start
 
 docker-start:
-	docker-compose up -d
+	docker compose up -d
 
 docker-stop:
-	docker-compose down
+	docker compose down
 
 admin:
 	$(PYTHON) $(MAIN) createsuperuser

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@
 
 # Define variables
 MAKE          := make
-VENV 		  := .venv
-PYTHON    	  := $(VENV)/bin/python3
+VENV		  := .venv
+PYTHON		  := $(VENV)/bin/python3
 
 # Define directories
 MEDIA_DIR     := media

--- a/automoss/settings.py
+++ b/automoss/settings.py
@@ -156,7 +156,7 @@ DEFAULT_FROM_EMAIL = "automossapp@gmail.com"
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'Africa/Johannesburg'
+TIME_ZONE = 'America/Chicago'
 
 USE_I18N = True
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,13 @@ services:
       - sql_data:/var/lib/mysql
     ports:
       - 8000:80
+    depends_on:
+      - redis
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+
 volumes:
   media_data:
   sql_data:
-  


### PR DESCRIPTION
Install Python requirements errors with the following:

```bash
22.49 pip3 install -r requirements_dev.txt --upgrade
22.62 error: externally-managed-environment
22.62 
22.62 × This environment is externally managed
22.62 ╰─> To install Python packages system-wide, try apt install
22.62     python3-xyz, where xyz is the package you are trying to
22.62     install.
22.62     
22.62     If you wish to install a non-Debian-packaged Python package,
22.62     create a virtual environment using python3 -m venv path/to/venv.
22.62     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
22.62     sure you have python3-full installed.
22.62     
22.62     If you wish to install a non-Debian packaged Python application,
22.62     it may be easiest to use pipx install xyz, which will manage a
22.62     virtual environment for you. Make sure you have pipx installed.
22.62     
22.62     See /usr/share/doc/python3.12/README.venv for more information.
22.62 
22.62 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
22.62 hint: See PEP 668 for the detailed specification.
22.65 make: *** [Makefile:24: install] Error 1
------
failed to solve: process "/bin/sh -c make install" did not complete successfully: exit code: 2
```

Installing this with a virtual environment fixes the issue.